### PR TITLE
Implement The http.Client Interface

### DIFF
--- a/examples/examples.go
+++ b/examples/examples.go
@@ -29,7 +29,7 @@ func main() {
 
 func example1() error {
 	url := strings.Join([]string{baseURL, "get"}, "/")
-	resp, err := xhttp.Get(url)
+	resp, err := xhttp.GET(url)
 	if err != nil {
 		return errors.Wrapf(err, "http request failed: method %s, url %s", http.MethodGet, url)
 	}

--- a/xhttp_test.go
+++ b/xhttp_test.go
@@ -41,7 +41,7 @@ func TestGet(t *testing.T) {
 			srv := httptest.NewServer(http.Handler(createTestHandler(tc.expected.code, tc.expected.msg)))
 
 			var err error
-			tc.actual, err = Get(srv.URL)
+			tc.actual, err = GET(srv.URL)
 			if err != nil {
 				srv.Close()
 				tt.Errorf("failed to GET: %s", err)
@@ -115,7 +115,7 @@ func TestSendRaw(t *testing.T) {
 				tt.Errorf("failed to Send: %s", err)
 			}
 
-			tc.actual, err = SendRaw(req)
+			tc.actual, err = Do(req)
 			if err != nil {
 				srv.Close()
 				tt.Errorf("failed to Send: %s", err)
@@ -146,7 +146,7 @@ func TestPost(t *testing.T) {
 			srv := httptest.NewServer(http.Handler(createTestHandler(tc.expected.code, tc.expected.msg)))
 
 			var err error
-			tc.actual, err = Post(srv.URL, "application/octet-stream", tc.expected.body)
+			tc.actual, err = POST(srv.URL, "application/octet-stream", tc.expected.body)
 			if err != nil {
 				srv.Close()
 				tt.Errorf("failed to Send: %s", err)
@@ -313,7 +313,7 @@ func testClientGet(t *testing.T, c *Client) {
 			srv := httptest.NewServer(http.Handler(createTestHandler(tc.expected.code, tc.expected.msg)))
 
 			var err error
-			tc.actual, err = c.Get(srv.URL)
+			tc.actual, err = c.GET(srv.URL)
 			if err != nil {
 				srv.Close()
 				tt.Errorf("failed to GET: %s", err)


### PR DESCRIPTION
This PR updates the package with a breaking change. It makes the public api of the client to be the same as the default `net/http.Client` has.

This is to make it easier to use a custom client. While it exposes the underlying client, it may be useful to define an interface, and then use it instead of the stdlib client.
