### PR TITLE
Add UnmarshalJSONTo to Response

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/golocron/xhttp
 
 go 1.12
 
-require github.com/pkg/errors v0.8.1
+require (
+	github.com/pkg/errors v0.8.1
+	github.com/stretchr/testify v1.4.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,12 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/xhttp_test.go
+++ b/xhttp_test.go
@@ -9,6 +9,8 @@ import (
 	"net/url"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type testCase struct {
@@ -289,6 +291,29 @@ func TestRequest_SetAuthorization(t *testing.T) {
 
 	if act := req.Header.Get(expHeader); act != expValue {
 		t.Errorf("expected %s, got %s", expValue, act)
+	}
+}
+
+func TestResponse_UnmarshalJSONTo(t *testing.T) {
+	resp := &Response{Body: []byte(`{"name": "test"}`)}
+	val := &struct {
+		Name string `json:"name"`
+	}{}
+
+	{
+		err := resp.UnmarshalJSONTo(val)
+		assert.Equal(t, nil, err)
+
+		exp := &struct {
+			Name string `json:"name"`
+		}{Name: "test"}
+
+		assert.Equal(t, exp, val)
+	}
+
+	{
+		err := resp.UnmarshalJSONTo(*val)
+		assert.Equal(t, ErrInvalidValue, err)
 	}
 }
 


### PR DESCRIPTION
This PR updates the `Response` type with the `UnmarshalJSONTo` method.
